### PR TITLE
Local-AI daily news pipeline, ads, and JSON-LD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+# Hugo build outputs
+/public/
+/resources/
+.hugo_build.lock
+
+# OS/editor
+.DS_Store
+Thumbs.db
+.idea/
+.vscode/
+
+# Node / tooling
+node_modules/
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+
+# Python venv and caches
+.venv/
+__pycache__/
+*.pyc
+
+# Logs and dumps
+logs/
+*.log
+*.tmp
+
+# Env files
+.env
+.env.*
+
+# Submodule build artifacts (none by default)
+# themes/*/node_modules/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "themes/PaperMod"]
+	path = themes/PaperMod
+	url = https://github.com/adityatelange/hugo-PaperMod

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+SHELL := /bin/bash
+VENV := .venv
+run:
+	@hugo server -D --disableFastRender --bind 0.0.0.0
+serve: run
+
+deps:
+	@test -d $(VENV) || python3 -m venv $(VENV)
+	@source $(VENV)/bin/activate && pip install -r scripts/requirements.txt
+
+# Existing combined generator (kept for compatibility)
+generate:
+	@source $(VENV)/bin/activate && python scripts/fetch_and_generate.py || true
+
+# New pipeline targets
+fetch:
+	@source $(VENV)/bin/activate && python scripts/fetch_sources.py
+
+draft:
+	@source $(VENV)/bin/activate && python scripts/generate_post.py
+
+calendar:
+	@source $(VENV)/bin/activate && python scripts/build_calendar.py
+
+review:
+	@source $(VENV)/bin/activate && python scripts/review.py || true
+
+build:
+	@hugo --minify
+
+publish:
+	@git add .
+	@git commit -m "content: publish updates" || true
+	@git push origin main

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ Cloudflare Pages deployment (recommended)
    - Environment variable: HUGO_VERSION=0.146.0
 3) Add the custom domain (hashnhedge.com) and follow DNS instructions.
 
+Automation (cron in US Central Time)
+- Example crontab entry using CRON_TZ for Central Time (no system timezone change needed):
+  CRON_TZ=America/Chicago
+  0 13 * * * cd /home/gnul/projects/hashnhedge/hashnhedge/site && /bin/bash -lc 'source .venv/bin/activate && make fetch draft publish' >> var/cron.log 2>&1
+- To install:
+  crontab -e
+  # paste the two lines above
+
 Hugo config notes
 - baseURL: https://hashnhedge.com/
 - Pagination: [pagination].pagerSize = 12

--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
-# hashnhedge
-news site
+# Hash n Hedge – Hugo + PaperMod
+
+This is the Hash n Hedge news site powered by Hugo and the PaperMod theme.
+
+Local development
+- make run        # runs `hugo server -D --disableFastRender`
+- make serve      # alias for run
+- make build      # runs `hugo --minify`
+
+Daily content pipeline (local AI)
+- make deps       # set up Python venv and install requirements
+- make fetch      # fetch RSS sources into var/seen.db (SQLite)
+- make draft      # generate today's Daily SEO Brief at content/news/YYYY/MM/slug/index.md
+- make calendar   # generate data/calendar.csv for 30 days
+
+Advertising & SEO
+- Update params.ads in config/_default/hugo.toml with your AdSense client_id.
+- Enable ads via params.ads.enabled=true or export ADS_ENABLED=1 for local testing.
+- In-article ad shortcode: {{< ad_in_article slot="YOUR_SLOT" >}}
+- static/ads.txt must contain your publisher ID entry.
+- NewsArticle JSON-LD is auto-included on news section pages.
+
+Cloudflare Pages deployment (recommended)
+1) Connect this repository in Cloudflare Pages.
+2) Settings:
+   - Framework: Hugo
+   - Build command: hugo
+   - Output directory: public
+   - Environment variable: HUGO_VERSION=0.146.0
+3) Add the custom domain (hashnhedge.com) and follow DNS instructions.
+
+Hugo config notes
+- baseURL: https://hashnhedge.com/
+- Pagination: [pagination].pagerSize = 12
+- Theme: PaperMod (see themes/PaperMod)

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -23,8 +23,8 @@ timeout = "120s"
 [params]
   # Ads config: controlled via params and environment.
   [params.ads]
-    enabled = true             # ads enabled; update client_id when available
-    client_id = "ca-pub-REPLACE_ME"
+    enabled = true             # enable ads in production (script still requires a client id)
+    client_id = "ca-pub-876996253611"
     # Optional default slots; can be overridden per shortcode use
     slot_in_article_top = "1234567890"
     slot_in_article_mid = "1234567891"

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -1,0 +1,34 @@
+baseURL = "https://hashnhedge.com/"
+title = "Hash n Hedge"
+languageCode = "en-us"
+theme = "PaperMod"
+enableRobotsTXT = true
+canonifyURLs = true
+enableGitInfo = true
+buildDrafts = false
+timeout = "120s"
+[pagination]
+  pagerSize = 12
+[permalinks]
+  posts = "/:year/:month/:day/:slug/"
+[minify]
+  [minify.tdewolff.html]
+    keepWhitespace = false
+[outputs]
+  home = ["HTML", "RSS", "JSON"]
+[privacy]
+  [privacy.googleAnalytics]
+    anonymizeIP = true
+
+[params]
+  # Ads config: controlled via params and environment.
+  [params.ads]
+    enabled = false            # set true in production when ready
+    client_id = "ca-pub-REPLACE_ME"
+    # Optional default slots; can be overridden per shortcode use
+    slot_in_article_top = "1234567890"
+    slot_in_article_mid = "1234567891"
+
+  # News section configuration for JSON-LD inclusion
+  [params.news]
+    section = "news"

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -23,7 +23,7 @@ timeout = "120s"
 [params]
   # Ads config: controlled via params and environment.
   [params.ads]
-    enabled = false            # set true in production when ready
+    enabled = true             # ads enabled; update client_id when available
     client_id = "ca-pub-REPLACE_ME"
     # Optional default slots; can be overridden per shortcode use
     slot_in_article_top = "1234567890"

--- a/data/sources.yml
+++ b/data/sources.yml
@@ -1,0 +1,21 @@
+categories:
+  core:
+    - name: Google Search Central
+      url: https://developers.google.com/search/blog.rss
+    - name: Search Engine Roundtable
+      url: https://www.seroundtable.com/rss.xml
+    - name: Search Engine Land
+      url: https://searchengineland.com/feed
+    - name: Bing Webmaster Blog
+      url: https://blogs.bing.com/webmaster/feed
+    - name: Google Ads
+      url: https://blog.google/products/ads/rss/
+    - name: Google AI Blog
+      url: https://ai.googleblog.com/feeds/posts/default
+    - name: Yoast SEO
+      url: https://yoast.com/feed/
+    - name: Ahrefs Blog
+      url: https://ahrefs.com/blog/rss/
+    - name: Semrush Blog
+      url: https://www.semrush.com/blog/rss/
+

--- a/layouts/partials/extend_head.html
+++ b/layouts/partials/extend_head.html
@@ -1,0 +1,19 @@
+{{/*
+  This partial is auto-included by PaperMod's head.html.
+  - Injects AdSense script only when ads are enabled and in production (or ADS_ENABLED=1).
+  - Injects NewsArticle JSON-LD for pages in the configured news section.
+*/}}
+
+{{ $adsEnabled := and (site.Params.ads.enabled) (or (hugo.IsProduction) (eq (getenv "ADS_ENABLED") "1")) }}
+
+{{ if $adsEnabled }}
+  {{ with site.Params.ads.client_id }}
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client={{ . }}" crossorigin="anonymous"></script>
+  {{ end }}
+{{ end }}
+
+{{/* NewsArticle JSON-LD only on single pages within the news section */}}
+{{ $newsSection := default "news" site.Params.news.section }}
+{{ if and .IsPage (eq .Section $newsSection) }}
+  {{ partial "news_article.jsonld.html" . }}
+{{ end }}

--- a/layouts/partials/extend_head.html
+++ b/layouts/partials/extend_head.html
@@ -4,12 +4,24 @@
   - Injects NewsArticle JSON-LD for pages in the configured news section.
 */}}
 
-{{ $adsEnabled := and (site.Params.ads.enabled) (or (hugo.IsProduction) (eq (getenv "ADS_ENABLED") "1")) }}
+{{/* Consent Mode v2: default denied until a CMP or banner updates consent. */}}
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);} 
+  gtag('consent','default',{
+    'ad_storage':'denied',
+    'ad_user_data':'denied',
+    'ad_personalization':'denied',
+    'analytics_storage':'denied'
+  });
+</script>
 
-{{ if $adsEnabled }}
-  {{ with site.Params.ads.client_id }}
-    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client={{ . }}" crossorigin="anonymous"></script>
-  {{ end }}
+{{/* Hugo security blocks getenv by default; rely solely on site params. */}}
+{{ $adsEnabled := and (site.Params.ads.enabled) (hugo.IsProduction) }}
+{{ $client := site.Params.ads.client_id }}
+
+{{ if and $adsEnabled $client }}
+  cscript async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client={{ $client }}" crossorigin="anonymous"ec/scripte
 {{ end }}
 
 {{/* NewsArticle JSON-LD only on single pages within the news section */}}

--- a/layouts/partials/news_article.jsonld.html
+++ b/layouts/partials/news_article.jsonld.html
@@ -1,0 +1,14 @@
+{{/* JSON-LD for NewsArticle; include only on news section pages via extend_head.html */}}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": {{ .Title | jsonify }},
+  "datePublished": {{ .Date.Format "2006-01-02T15:04:05Z07:00" | jsonify }},
+  "dateModified": {{ .Lastmod.Format "2006-01-02T15:04:05Z07:00" | jsonify }},
+  "author": { "@type": "Person", "name": {{ (or .Params.author site.Title) | jsonify }} },
+  "publisher": { "@type": "Organization", "name": {{ site.Title | jsonify }} },
+  "description": {{ (or .Params.description .Summary) | jsonify }},
+  "mainEntityOfPage": {{ .Permalink | jsonify }}
+}
+</script>

--- a/layouts/shortcodes/ad_in_article.html
+++ b/layouts/shortcodes/ad_in_article.html
@@ -1,0 +1,14 @@
+{{/* Responsive in-article ad. Usage in content: {{< ad_in_article slot="1234567890" >}} */}}
+{{ $adsEnabled := and (site.Params.ads.enabled) (or (hugo.IsProduction) (eq (getenv "ADS_ENABLED") "1")) }}
+{{ if $adsEnabled }}
+  {{ $slot := or (.Get "slot") site.Params.ads.slot_in_article_mid }}
+  <ins class="adsbygoogle" style="display:block; text-align:center; min-height: 180px"
+       data-ad-layout="in-article"
+       data-ad-format="fluid"
+       data-ad-client="{{ site.Params.ads.client_id }}"
+       data-ad-slot="{{ $slot }}"></ins>
+  <script>(adsbygoogle=window.adsbygoogle||[]).push({});</script>
+{{ else }}
+  {{/* Placeholder to preserve layout during development / when ads disabled */}}
+  <div style="display:block; text-align:center; min-height: 180px; opacity: .25; border: 1px dashed #ccc">Ad placeholder</div>
+{{ end }}

--- a/scripts/build_calendar.py
+++ b/scripts/build_calendar.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+import csv, datetime as dt
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA = ROOT / "data"
+DATA.mkdir(parents=True, exist_ok=True)
+CAL = DATA / "calendar.csv"
+
+start = dt.date.today()
+rows = []
+for i in range(30):
+    d = start + dt.timedelta(days=i)
+    rows.append({"date": d.isoformat(), "slug": f"daily-seo-brief-{d.isoformat()}", "type": "news"})
+
+with CAL.open("w", newline="") as f:
+    w = csv.DictWriter(f, fieldnames=["date","slug","type"])
+    w.writeheader()
+    for r in rows:
+        w.writerow(r)
+
+print(f"Wrote {CAL}")
+

--- a/scripts/config.yaml
+++ b/scripts/config.yaml
@@ -1,0 +1,36 @@
+site:
+  base_url: "https://hashnhedge.com"
+  author: "Hash n Hedge Staff"
+content:
+  daily_target: 12
+  min_words: 600
+  max_words: 900
+  review_required: true
+  drafts_dir: "content/drafts"
+  posts_dir: "content/posts"
+  og_dir: "static/images/og"
+  categories: ["Cybersecurity","AI","Fintech","Linux","Crypto","Markets","Macro","Tech"]
+ai:
+  provider: "ollama"
+  model: "llama3.1:8b"
+  temperature: 0.7
+  top_p: 0.9
+  max_tokens: 1024
+sources:
+  rss:
+    - "https://krebsonsecurity.com/feed/"
+    - "https://feeds.feedburner.com/TheHackersNews"
+    - "https://www.bleepingcomputer.com/feed/"
+    - "https://www.cisa.gov/cybersecurity-advisories/rss.xml"
+    - "https://nvd.nist.gov/feeds/xml/cve/misc/nvd-rss-analyzed.xml"
+    - "https://ai.googleblog.com/feeds/posts/default?alt=rss"
+    - "https://openai.com/blog/rss.xml"
+    - "https://huggingface.co/blog/feed.xml"
+    - "https://www.reuters.com/markets/technology/rss"
+    - "https://www.coindesk.com/arc/outboundfeeds/rss/"
+    - "https://cointelegraph.com/rss"
+    - "https://phoronix.com/rss.php"
+    - "https://lwn.net/headlines/rss"
+  blocklist_keywords: ["opinion","sponsored","podcast"]
+store:
+  dedup_db: "data/dedup.sqlite"

--- a/scripts/fetch_and_generate.py
+++ b/scripts/fetch_and_generate.py
@@ -1,0 +1,132 @@
+import os, re, json, hashlib, sqlite3, time
+from datetime import datetime, timezone
+from urllib.parse import urlparse
+import httpx, feedparser, frontmatter, yaml
+from slugify import slugify
+import trafilatura
+from ruamel.yaml import YAML
+
+CFG = yaml.safe_load(open('scripts/config.yaml','r'))
+DRAFTS = CFG['content']['drafts_dir']
+POSTS = CFG['content']['posts_dir']
+os.makedirs(DRAFTS, exist_ok=True)
+os.makedirs(POSTS, exist_ok=True)
+os.makedirs(os.path.dirname(CFG['store']['dedup_db']), exist_ok=True)
+
+REVIEW = CFG['content'].get('review_required', True)
+
+def db():
+    conn = sqlite3.connect(CFG['store']['dedup_db'])
+    c = conn.cursor()
+    c.execute("CREATE TABLE IF NOT EXISTS seen (id TEXT PRIMARY KEY, url TEXT, created_at INTEGER)")
+    conn.commit()
+    return conn
+
+def norm_id(url):
+    return hashlib.sha256(url.encode()).hexdigest()
+
+def seen_before(conn, url):
+    nid = norm_id(url)
+    c = conn.cursor()
+    c.execute("SELECT 1 FROM seen WHERE id=?", (nid,))
+    if c.fetchone(): return True
+    c.execute("INSERT INTO seen (id,url,created_at) VALUES (?,?,?)", (nid, url, int(time.time())))
+    conn.commit()
+    return False
+
+def extract_text(url):
+    try:
+        downloaded = trafilatura.fetch_url(url, no_ssl=True)
+        if not downloaded: return None
+        text = trafilatura.extract(downloaded, include_comments=False, include_tables=False)
+        return text
+    except Exception:
+        return None
+
+def ollama_generate(prompt, model, temperature=0.7, top_p=0.9):
+    payload = {
+        "model": model,
+        "prompt": prompt,
+        "options": {"temperature": temperature, "top_p": top_p}
+    }
+    with httpx.stream("POST", "http://localhost:11434/api/generate", json=payload, timeout=120.0) as r:
+        buf = ""
+        for line in r.iter_lines():
+            if not line: continue
+            data = json.loads(line)
+            if 'response' in data: buf += data['response']
+        return buf
+
+def build_prompt(source_url, outlet, text):
+    date_iso = datetime.now(timezone.utc).isoformat()
+    instr = open('prompts/news_post.txt','r').read()
+    src = f"Source URL: {source_url}\nOutlet: {outlet}\n\nSource Text:\n{text}\n"
+    return f"{instr}\n\nNow write the article for {date_iso}.\n\n{src}"
+
+def parse_yaml_and_body(s):
+    m = re.match(r'---\s*\n(.*?)\n---\s*\n(.*)', s, re.S)
+    if not m:
+        raise ValueError("Model output missing YAML front matter.")
+    yml = YAML()
+    meta = yml.load(m.group(1))
+    body = m.group(2).strip()
+    return meta, body
+
+def write_post(meta, body, outlet, source_url):
+    title = meta.get('title') or 'Untitled'
+    date_slug = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    slug = slugify(title)[:80]
+    fname = f"{date_slug}-{slug}.md"
+    dst_dir = DRAFTS if REVIEW else POSTS
+    path = os.path.join(dst_dir, fname)
+    meta.setdefault('date', datetime.now(timezone.utc).isoformat())
+    meta.setdefault('draft', REVIEW)
+    meta.setdefault('source', {})
+    meta['source']['url'] = source_url
+    meta['source']['outlet'] = outlet
+    meta.setdefault('canonical_url', f"{CFG['site']['base_url'].rstrip('/')}/posts/{date_slug.replace('-','/')}/{slug}/")
+    meta.setdefault('cover', {'image':'', 'alt': title})
+    post = frontmatter.Post(body, **meta)
+    with open(path, 'w') as f:
+        frontmatter.dump(post, f)
+    print(f"Wrote {'draft' if REVIEW else 'post'}: {path}")
+
+
+def main():
+    conn = db()
+    wrote = 0
+    for feed in CFG['sources']['rss']:
+        d = feedparser.parse(feed)
+        for e in d.entries[:30]:
+            url = e.get('link')
+            title = e.get('title','')
+            if not url: continue
+            if any(k.lower() in title.lower() for k in CFG['sources']['blocklist_keywords']): continue
+            if seen_before(conn, url): continue
+            outlet = urlparse(url).netloc
+            text = extract_text(url) or e.get('summary','')
+            if not text or len(text) < 500: continue
+            prompt = build_prompt(url, outlet, text[:6000])
+            out = ollama_generate(prompt, CFG['ai']['model'], CFG['ai']['temperature'], CFG['ai']['top_p'])
+            try:
+                meta, body = parse_yaml_and_body(out)
+            except Exception:
+                # Fallback: wrap as simple post
+                meta = {
+                    "title": title[:60],
+                    "description": f"Summary of {title}",
+                    "categories": ["Tech"],
+                    "tags": ["news"],
+                    "seo": {"meta_title": title[:60], "meta_description": f"Summary of {title}"}
+                }
+                body = f"Source: {url}\n\n{out}"
+            write_post(meta, body, outlet, url)
+            wrote += 1
+            if wrote >= CFG['content']['daily_target']:
+                break
+        if wrote >= CFG['content']['daily_target']:
+            break
+    print("Done.")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fetch_sources.py
+++ b/scripts/fetch_sources.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+import yaml, sqlite3, sys, os
+import feedparser
+from urllib.parse import urlparse
+from pathlib import Path
+import requests_cache
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA = ROOT / "data" / "sources.yml"
+VAR = ROOT / "var"
+VAR.mkdir(parents=True, exist_ok=True)
+CACHE_DIR = VAR / "cache"
+CACHE_DIR.mkdir(parents=True, exist_ok=True)
+DB = VAR / "seen.db"
+
+requests_cache.install_cache(str(CACHE_DIR / 'http'), expire_after=3600)
+
+conn = sqlite3.connect(DB)
+cur = conn.cursor()
+cur.execute(
+    """
+    CREATE TABLE IF NOT EXISTS items (
+      id INTEGER PRIMARY KEY,
+      url TEXT UNIQUE,
+      title TEXT,
+      source TEXT,
+      published TEXT,
+      added_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      used INTEGER DEFAULT 0
+    )
+    """
+)
+
+cfg = yaml.safe_load(DATA.read_text())
+feeds = [f['url'] for cat in cfg['categories'].values() for f in cat]
+
+added = 0
+for feed in feeds:
+    d = feedparser.parse(feed)
+    for e in d.entries:
+        url = e.get('link')
+        title = e.get('title')
+        published = e.get('published', '')
+        if not url:
+            continue
+        try:
+            cur.execute(
+                "INSERT OR IGNORE INTO items(url,title,source,published) VALUES(?,?,?,?)",
+                (url, title, urlparse(feed).netloc, published),
+            )
+            if cur.rowcount:
+                added += 1
+        except Exception:
+            pass
+
+conn.commit()
+print(f"Fetched feeds. New items added: {added}")
+

--- a/scripts/generate_post.py
+++ b/scripts/generate_post.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+import sqlite3, datetime as dt, json, os
+from pathlib import Path
+import frontmatter, yaml, requests, bs4
+from slugify import slugify
+import subprocess
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTENT = ROOT / "content" / "news"
+CONTENT.mkdir(parents=True, exist_ok=True)
+VAR = ROOT / "var"
+DB = VAR / "seen.db"
+
+def pick_items(limit=6, days=2):
+    conn = sqlite3.connect(DB)
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT url,title,source,published FROM items WHERE used=0 ORDER BY COALESCE(published, added_at) DESC LIMIT ?",
+        (limit,),
+    )
+    rows = cur.fetchall()
+    conn.close()
+    return rows
+
+def collect_snippets(items):
+    out = []
+    for url, title, source, published in items:
+        out.append(f"- {title} ({url})")
+    return "\n".join(out)
+
+def summarize(sources_blob: str) -> dict:
+    proc = subprocess.run(["python3", str(ROOT / "scripts" / "summarize.py")], input=sources_blob.encode(), stdout=subprocess.PIPE)
+    text = proc.stdout.decode()
+    try:
+        # Model may return JSON or Markdown with JSON fenced; try to locate JSON
+        start = text.find('{')
+        end = text.rfind('}')
+        js = json.loads(text[start:end+1])
+        return js
+    except Exception:
+        # Fallback minimal structure
+        return {
+            "title": "Daily SEO Brief",
+            "description": "Top SEO updates today.",
+            "sections": text,
+            "bullets": [],
+            "takeaways": []
+        }
+
+def write_post(payload: dict, date: dt.date, sources_list):
+    slug = slugify(payload.get("title") or f"daily-seo-brief-{date.isoformat()}")
+    post_dir = CONTENT / str(date.year) / f"{date.month:02d}" / slug
+    post_dir.mkdir(parents=True, exist_ok=True)
+    md_path = post_dir / "index.md"
+    fm = {
+        "title": payload.get("title", f"Daily SEO Brief: {date.isoformat()}"),
+        "description": payload.get("description", "Top SEO updates today."),
+        "date": dt.datetime.combine(date, dt.time(13,0)).isoformat() + "Z",
+        "tags": ["news","seo"],
+        "draft": False,
+        "sources": [{"title": s[1], "url": s[0]} for s in sources_list],
+        "author": "Hash n Hedge",
+    }
+    body = ""
+    if payload.get("sections"):
+        body += payload["sections"] + "\n\n"
+    if payload.get("takeaways"):
+        body += "## What this means for SEOs\n\n" + "\n".join([f"- {t}" for t in payload["takeaways"]]) + "\n\n"
+    body += "## Sources\n\n" + "\n".join([f"- [{title}]({url})" for (url,title,_,_) in sources_list]) + "\n"
+
+    post = frontmatter.Post(body, **fm)
+    md_path.write_bytes(frontmatter.dumps(post).encode())
+    return md_path
+
+if __name__ == "__main__":
+    today = dt.date.today()
+    items = pick_items()
+    if not items:
+        print("No items available. Run scripts/fetch_sources.py first.")
+        raise SystemExit(0)
+    blob = collect_snippets(items)
+    summary = summarize(blob)
+    path = write_post(summary, today, items)
+    # Mark items as used
+    conn = sqlite3.connect(DB); cur = conn.cursor()
+    for (url, *_rest) in items:
+        cur.execute("UPDATE items SET used=1 WHERE url=?", (url,))
+    conn.commit(); conn.close()
+    print(f"Wrote {path}")
+

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,17 @@
+feedparser==6.0.11
+httpx==0.27.0
+beautifulsoup4==4.12.3
+trafilatura==1.9.0
+python-frontmatter==1.0.1
+python-slugify==8.0.4
+pillow==10.4.0
+ruamel.yaml==0.18.6
+jinja2==3.1.4
+pydantic==2.8.2
+readabilipy==0.2.0
+tqdm==4.66.4
+regex==2024.5.15
+# Added for local AI pipeline scripts
+PyYAML==6.0.2
+requests==2.32.3
+requests-cache==1.2.0

--- a/scripts/review.py
+++ b/scripts/review.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+import os, subprocess, shutil, yaml
+CFG = yaml.safe_load(open('scripts/config.yaml','r'))
+DRAFTS = CFG['content']['drafts_dir']
+POSTS = CFG['content']['posts_dir']
+EDITOR = os.environ.get('EDITOR','nano')
+
+def list_drafts():
+  return sorted([os.path.join(DRAFTS,f) for f in os.listdir(DRAFTS) if f.endswith('.md')])
+
+def approve(path):
+  with open(path,'r') as f:
+    data = f.read().replace("\ndraft: true","\ndraft: false")
+  with open(path,'w') as f:
+    f.write(data)
+  slug = os.path.basename(path)
+  target = os.path.join(POSTS, slug)
+  os.makedirs(POSTS, exist_ok=True)
+  shutil.move(path, target)
+  print(f"Approved -> {target}")
+
+def main():
+  ds = list_drafts()
+  for p in ds:
+    print(f"\nReviewing: {p}\n")
+    subprocess.call([EDITOR, p])
+    ans = input("Approve and publish? y/N: ").strip().lower()
+    if ans == 'y':
+      approve(p)
+
+if __name__ == "__main__":
+  main()

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+import subprocess, sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+MODEL = "qwen2.5:7b-instruct"
+TEMP = "0.3"
+
+PROMPT = f"""You are an SEO news editor.
+Inputs: a list of source headlines and links with snippets.
+Tasks:
+1) Summarize top 3-6 items with neutral tone.
+2) Add a 'What this means for SEOs' section with actionable takeaways.
+3) Write an SEO title (<=60 chars) and meta description (<=155 chars).
+Output JSON with keys: title, description, sections (markdown), bullets (list), takeaways (list).
+"""
+
+def ollama_run(prompt: str, model: str = MODEL):
+    proc = subprocess.run(["ollama", "run", model], input=prompt.encode(), stdout=subprocess.PIPE)
+    return proc.stdout.decode()
+
+if __name__ == "__main__":
+    sources_blob = sys.stdin.read()
+    out = ollama_run(PROMPT + "\n\nSources:\n" + sources_blob)
+    print(out)
+

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -4,8 +4,9 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 
-MODEL = "qwen2.5:7b-instruct"
-TEMP = "0.3"
+import os
+MODEL = os.getenv("OLLAMA_MODEL", "qwen2.5:7b-instruct")
+TEMP = os.getenv("OLLAMA_TEMP", "0.3")
 
 PROMPT = f"""You are an SEO news editor.
 Inputs: a list of source headlines and links with snippets.

--- a/static/ads.txt
+++ b/static/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-876996253611, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
This PR adds:\n- Local AI daily news pipeline scripts (fetch, summarize via Ollama, generate)\n- Conditional ad slots (AdSense) + in-article shortcode\n- NewsArticle JSON-LD partial and head wiring for news posts\n- 30-day content calendar scaffold\n- Hugo pagination config update for v0.146+\n\nHow to test:\n- make deps\n- make fetch\n- make draft\n- hugo --minify\n\nAds:\n- Set params.ads.client_id to your AdSense ID\n- Set params.ads.enabled=true (or export ADS_ENABLED=1)\n\nNotes:\n- Built locally on Hugo v0.146.0 with PaperMod.\n